### PR TITLE
Fix overload order for `MultiThreaded.new`

### DIFF
--- a/src/multi_threaded.cr
+++ b/src/multi_threaded.cr
@@ -25,10 +25,6 @@ module ExecutionContext
       new("DEFAULT", size, hijack: true)
     end
 
-    def self.new(name : String, size : Int32) : self
-      new(name, size, hijack: false)
-    end
-
     protected def initialize(@name : String, @size : Int32, hijack = false)
       raise "ERROR: needs at least one thread" if @size <= 0
 
@@ -48,6 +44,10 @@ module ExecutionContext
       # self.spawn(name: "#{@name}:stackpool-collect") do
       #   stack_pool.collect_loop
       # end
+    end
+
+    def self.new(name : String, size : Int32) : self
+      new(name, size, hijack: false)
     end
 
     # Starts `count` schedulers and threads.


### PR DESCRIPTION
This is a workaround for faulty overload ordering by the compiler that cannot be fixed without breaking backwards compatibilty (https://github.com/crystal-lang/crystal/pull/10711).

The compile time flag `-Dpreview_overload_order` can be used to opt-in to the fixed behaviour. But without it, the non-protected def must be after the protected one.