### PR TITLE
Adding an example of a dedicated ST EC dispatching to a MT EC

### DIFF
--- a/bench/Makefile
+++ b/bench/Makefile
@@ -5,8 +5,9 @@ CRFLAGS=--release
 
 FIBER_QSORT_BINARIES=fiber_qsort fiber_qsort-mt fiber_qsort-ec fiber_qsort-ec-mt
 HTTP_SERVER_BINARIES=http_server http_server-mt http_server-ec http_server-ec-mt
+HTTP_DISPATCH_BINARIES=http_dispatch http_dispatch-mt http_dispatch-ec http_dispatch-ec-mt
 
-all: $(FIBER_QSORT_BINARIES) $(HTTP_SERVER_BINARIES)
+all: $(FIBER_QSORT_BINARIES) $(HTTP_SERVER_BINARIES) $(HTTP_DISPATCH_BINARIES)
 
 %: %.cr ../src/*.cr ../src/**/*.cr
 	$(CRYSTAL) build $(CRFLAGS) $< -o $@
@@ -21,6 +22,6 @@ all: $(FIBER_QSORT_BINARIES) $(HTTP_SERVER_BINARIES)
 	$(CRYSTAL) build -Dpreview_mt -Dec -Dmt $(CRFLAGS) $< -o $@
 
 clean: .phony
-	rm -f $(FIBER_QSORT_BINARIES) $(HTTP_SERVER_BINARIES)
+	rm -f $(FIBER_QSORT_BINARIES) $(HTTP_SERVER_BINARIES) $(HTTP_DISPATCH_BINARIES)
 
 .phony:

--- a/bench/http_dispatch.cr
+++ b/bench/http_dispatch.cr
@@ -1,4 +1,10 @@
 # A server listening on port 8080 that dispatches requests to different handlers
+#
+# With the `ec` flag, the server uses two ExecutionContexts to manage the threads,
+# SingleThreaded one for accepting connections, and MultiThreaded for processing responses.
+#
+# With the `mt` flag, the server uses a single ExecutionContext for both accepting connections
+# and processing responses.
 {% if flag?(:ec) %}
   require "../src/execution_context"
 {% end %}
@@ -6,23 +12,23 @@ require "socket"
 require "http/server/request_processor"
 
 THREAD_COUNT = (ENV["CRYSTAL_WORKERS"]?.try(&.to_i?) || 4) - 1 # 1 thread is the dedicated thread
-MSG_SIZE = ENV["BENCH_MSG_SIZE"]?.try(&.to_i?) || 1000
-MSG = "a" * MSG_SIZE
+MSG_SIZE     = ENV["BENCH_MSG_SIZE"]?.try(&.to_i?) || 1000
+MSG          = "a" * MSG_SIZE
 
 class Dispatcher
-  {% if flag?(:ec) %}
+  {% if flag?(:ec) && !flag?(:mt) %}
     @mt : ExecutionContext::MultiThreaded? = nil
   {% end %}
 
   def initialize(@processor : HTTP::Server::RequestProcessor)
-    {% if flag?(:ec) %}
+    {% if flag?(:ec) && !flag?(:mt) %}
       @mt = ExecutionContext::MultiThreaded.new("MT", (THREAD_COUNT..THREAD_COUNT))
     {% end %}
   end
 
   def dispatch(io)
     {% begin %}
-    {% if flag?(:ec) %}
+    {% if flag?(:ec) && !flag?(:mt) %}
       @mt.not_nil!.spawn do
     {% else %}
       spawn do
@@ -33,14 +39,14 @@ class Dispatcher
       end
     {% end %}
   end
-  
 end
 
-{% if flag?(:ec) %}
+{% if flag?(:ec) && !flag?(:mt) %}
   # Sets the main thread to be part of the SingleThreaded execution context
+  # TODO: I think this is unnecessary, and with `ec` but no `mt`, the main thread
+  # is already part of the SingleThreaded execution context
   ExecutionContext::SingleThreaded.default
 {% end %}
-
 
 socket = TCPServer.new(Socket::IPAddress::LOOPBACK, 8080, reuse_port: true)
 processor = HTTP::Server::RequestProcessor.new do |context|

--- a/bench/http_dispatch.cr
+++ b/bench/http_dispatch.cr
@@ -1,0 +1,68 @@
+# A server listening on port 8080 that dispatches requests to different handlers
+{% if flag?(:ec) %}
+  require "../src/execution_context"
+{% end %}
+require "socket"
+require "http/server/request_processor"
+
+THREAD_COUNT = (ENV["CRYSTAL_WORKERS"]?.try(&.to_i?) || 4) - 1 # 1 thread is the dedicated thread
+MSG_SIZE = ENV["BENCH_MSG_SIZE"]?.try(&.to_i?) || 1000
+MSG = "a" * MSG_SIZE
+
+class Dispatcher
+  {% if flag?(:ec) %}
+    @mt : ExecutionContext::MultiThreaded? = nil
+  {% end %}
+
+  def initialize(@processor : HTTP::Server::RequestProcessor)
+    {% if flag?(:ec) %}
+      @mt = ExecutionContext::MultiThreaded.new("MT", (THREAD_COUNT..THREAD_COUNT))
+    {% end %}
+  end
+
+  def dispatch(io)
+    {% begin %}
+    {% if flag?(:ec) %}
+      @mt.not_nil!.spawn do
+    {% else %}
+      spawn do
+    {% end %}
+        @processor.process io, io
+      ensure 
+        io.close
+      end
+    {% end %}
+  end
+  
+end
+
+{% if flag?(:ec) %}
+  # Sets the main thread to be part of the SingleThreaded execution context
+  ExecutionContext::SingleThreaded.default
+{% end %}
+
+
+socket = TCPServer.new(Socket::IPAddress::LOOPBACK, 8080, reuse_port: true)
+processor = HTTP::Server::RequestProcessor.new do |context|
+  context.response.content_type = "text/plain"
+  context.response.print(MSG)
+end
+
+dispatcher = Dispatcher.new(processor)
+puts "Listening on http://#{socket.local_address}"
+socket.listen
+
+loop do
+  io = begin
+    socket.accept?
+  rescue e
+    STDERR.puts e
+    next
+  end
+
+  if io
+    dispatcher.dispatch(io)
+  else
+    break
+  end
+end


### PR DESCRIPTION
Benchmarks (all of them with 30s and 40 connections):

 * wrk running 2 threads, default workers (4), 1000 bytes request

```
preview_mt:
  Requests/sec:  79505.69
  Transfer/sec:     82.72M
ec:
  Requests/sec:  64983.74
  Transfer/sec:     67.61MB
```

 * wrk running 2 threads, 8 workers, 1000 bytes request

```
preview_mt:
  Requests/sec:  73082.06
  Transfer/sec:     76.04MB
ec:
  Requests/sec:  86116.64
  Transfer/sec:     89.60MB 
```

 * wrk running 4 threads, 6 workers, 4000 bytes request

```
preview_mt:
  Requests/sec:  44979.04
  Transfer/sec:    175.48MB
ec:
  Requests/sec:  45267.99
  Transfer/sec:    176.61MB
```