### PR TITLE
wrcr, a simple-minded wrk implementation in Crystal

### DIFF
--- a/bench/wrcr.cr
+++ b/bench/wrcr.cr
@@ -1,0 +1,74 @@
+{% if flag?(:ec) %}
+  require "../src/execution_context"
+{% end %}
+require "http/client"
+require "option_parser"
+
+
+address = "localhost:8080"
+duration = 30.seconds
+requests = 12
+fibers = 20
+
+OptionParser.parse do |parser|
+  parser.banner = "Usage: wrcr [arguments]\nNote: The number of threads is set by the CRYSTAL_WORKERS environment variable."
+  parser.on("-f NUMBER", "--fibers=NUMBER", "Number of total fibers. Defaults to #{fibers}") { |fbrs| fibers = fbrs.to_i }
+  parser.on("-r NUMBER", "--requests=NUMBER", "Number of requests before closing the connection. Defaults to #{requests}") { |req| requests = req.to_i }
+  parser.on("-d NUMBER", "--duration=NUMBER", "Duration of the test. Defaults to #{duration} seconds") { |dur| duration = dur.to_i.seconds }
+  parser.on("-u URL", "--url=URL", "Specifies the address of the server. Defaults to #{address}") { |url| address = url }
+  parser.on("-h", "--help", "Show this help") do
+    puts parser
+    exit
+  end
+  parser.invalid_option do |flag|
+    STDERR.puts "ERROR: #{flag} is not a valid option."
+    STDERR.puts parser
+    exit(1)
+  end
+end
+
+address = address.gsub("http://", "")
+if address.includes? ":"
+  address, port_s = address.split(":")
+  port = port_s.to_i
+else
+  port = 80
+end
+
+start = Time.local
+
+successes = Channel({Int32,Int64}).new(fibers)
+
+fibers.times do
+  spawn do
+    j = 0
+    bytes = 0_i64
+    client = HTTP::Client.new address, port
+    loop do
+      requests.times do
+        break if Time.local - start > duration
+        response = client.get "/"
+        if response.status_code == 200
+          j += 1
+          bytes += response.body.size
+        end
+      rescue IO::TimeoutError
+      rescue e
+        STDERR.puts e
+      end
+      break if Time.local - start > duration
+    end
+    successes.send({j, bytes})
+  end
+end
+
+total_successes = 0
+total_bytes = 0_i64
+
+fibers.times do
+  reqs, bytes = successes.receive
+  total_successes += reqs
+  total_bytes += bytes
+end
+
+puts "Total requests: #{total_successes}\nTotal bytes: #{total_bytes.humanize}"

--- a/bench/wrcr.cr
+++ b/bench/wrcr.cr
@@ -4,7 +4,6 @@
 require "http/client"
 require "option_parser"
 
-
 address = "localhost:8080"
 duration = 30.seconds
 requests = 12
@@ -37,7 +36,7 @@ end
 
 start = Time.local
 
-successes = Channel({Int32,Int64}).new(fibers)
+successes = Channel({Int32, Int64}).new(fibers)
 
 fibers.times do
   spawn do
@@ -71,4 +70,4 @@ fibers.times do
   total_bytes += bytes
 end
 
-puts "Total requests: #{total_successes}\nTotal bytes: #{total_bytes.humanize}"
+puts "Total requests: #{total_successes}\nTotal bytes read: #{total_bytes.humanize}"

--- a/bench/wrcr.cr
+++ b/bench/wrcr.cr
@@ -8,9 +8,13 @@ address = "localhost:8080"
 duration = 30.seconds
 requests = 12
 fibers = 20
+threads = 4
 
 OptionParser.parse do |parser|
-  parser.banner = "Usage: wrcr [arguments]\nNote: The number of threads is set by the CRYSTAL_WORKERS environment variable."
+  parser.banner = "Usage: wrcr [arguments]"
+  {% if flag?(:ec) && flag?(:mt) %}
+    parser.on("-t NUMBER", "--threads=NUMBER", "Number of total threads. Defaults to #{threads}") { |thrs| threads = thrs.to_i }
+  {% end %}
   parser.on("-f NUMBER", "--fibers=NUMBER", "Number of total fibers. Defaults to #{fibers}") { |fbrs| fibers = fbrs.to_i }
   parser.on("-r NUMBER", "--requests=NUMBER", "Number of requests before closing the connection. Defaults to #{requests}") { |req| requests = req.to_i }
   parser.on("-d NUMBER", "--duration=NUMBER", "Duration of the test. Defaults to #{duration} seconds") { |dur| duration = dur.to_i.seconds }
@@ -25,6 +29,10 @@ OptionParser.parse do |parser|
     exit(1)
   end
 end
+
+{% if flag?(:ec) && flag?(:mt) %}
+  ExecutionContext::MultiThreaded.default threads
+{% end %}
 
 address = address.gsub("http://", "")
 if address.includes? ":"

--- a/bench/wrcr.cr
+++ b/bench/wrcr.cr
@@ -17,7 +17,7 @@ OptionParser.parse do |parser|
   {% end %}
   parser.on("-f NUMBER", "--fibers=NUMBER", "Number of total fibers. Defaults to #{fibers}") { |fbrs| fibers = fbrs.to_i }
   parser.on("-r NUMBER", "--requests=NUMBER", "Number of requests before closing the connection. Defaults to #{requests}") { |req| requests = req.to_i }
-  parser.on("-d NUMBER", "--duration=NUMBER", "Duration of the test. Defaults to #{duration} seconds") { |dur| duration = dur.to_i.seconds }
+  parser.on("-d NUMBER", "--duration=NUMBER", "Duration of the test. Defaults to #{duration.total_seconds.to_i} seconds") { |dur| duration = dur.to_i.seconds }
   parser.on("-u URL", "--url=URL", "Specifies the address of the server. Defaults to #{address}") { |url| address = url }
   parser.on("-h", "--help", "Show this help") do
     puts parser


### PR DESCRIPTION
This client addresses the issue mentioned [in this comment](https://github.com/ysbaddaden/execution_context/pull/31#issuecomment-2333425068), opening and closing connections (unlike `wrk`).

With `CRYSTAL_WORKERS` it's possible to change the number of threads. Then, these are the additional options:

```
Usage: wrcr [arguments]
Note: The number of threads is set by the CRYSTAL_WORKERS environment variable.
    -f NUMBER, --fibers=NUMBER       Number of total fibers. Defaults to 20
    -r NUMBER, --requests=NUMBER     Number of requests before closing the connection. Defaults to 12
    -d NUMBER, --duration=NUMBER     Duration of the test. Defaults to 00:00:30 seconds
    -u URL, --url=URL                Specifies the address of the server. Defaults to localhost:8080
    -h, --help                       Show this help
```

There is no attempt at balancing the fibers, and that's why the option `-f` specifies the total number of fibers, resorting to the (EC:MT / preview_mt) scheduler to do it.

The number of requests is used in the loop to send to the server before closing the connection. Note: Connections are not re-allocated, instead, they're re-opened.

The duration of the test is approximated: at each request we check if we reach the time, and close gracefully.

Using the server from #31 with the EC:MT context, here's a poor-man's comparison with or without EC (three runs, 2 threads, server with 4 threads).

No EC: median of 1,332,637 requests, with MAD of 35,344.
EC: median of 1,341,610 requests, with MAD of 26,381.

Using the server with preview_mt:

No EC: median 1,538,338, MAD: 179,068
EC: median 1,623,682, MAD: 17,281

It's weird that this numbers are in contrast with the server's numbers when using wrk.