### PR TITLE
Mixing different types of loads: network, file, CPU

### DIFF
--- a/bench/mixed_load.cr
+++ b/bench/mixed_load.cr
@@ -4,17 +4,6 @@
 require "http/server"
 require "big"
 
-def fibonacci(n) : BigInt
-  a = BigInt.new(0)
-  b = BigInt.new(1)
-  n.times do
-    temp = a
-    a = b
-    b = temp + b
-  end
-  a
-end
-
 def take_some_time(n)
   count = BigInt.new 0
   while Time.local < n

--- a/bench/mixed_load.cr
+++ b/bench/mixed_load.cr
@@ -1,0 +1,51 @@
+{% if flag?(:ec) %}
+  require "../src/execution_context"
+{% end %}
+require "http/server"
+require "big"
+
+def fibonacci(n) : BigInt
+  a = BigInt.new(0)
+  b = BigInt.new(1)
+  n.times do
+    temp = a
+    a = b
+    b = temp + b
+  end
+  a
+end
+
+def take_some_time(n)
+  count = BigInt.new 0
+  while Time.local < n
+    count += 1
+  end
+  count
+end
+
+FIBER_COUNT = 10
+
+server = HTTP::Server.new do |context|
+  context.response.content_type = "text/plain"
+
+  ch = Channel(BigInt | String).new
+  FIBER_COUNT.times do |i|
+    if i % 2 == 0
+      spawn do
+        ch.send(take_some_time(Time.local + 1.seconds))
+      end
+    else
+      spawn do
+        contents = File.read(__FILE__)
+        ch.send contents
+      end
+    end
+  end
+  FIBER_COUNT.times do
+    context.response.print(ch.receive.to_s)
+  end
+end
+
+address = server.bind_tcp 8080, reuse_port: true
+puts "Listening on http://#{address}"
+server.listen


### PR DESCRIPTION
Here EC really shines. With `-Dpreview_mt -Dec -Dmt` it gets 1.8 req/s, while with just `-Dpreview_mt` it's less than 0.5. This is expected: if two CPU heavy tasks end in the same thread, since there's no snatching of tasks, it swamps the thread that then can't take further tasks.